### PR TITLE
ATHOS-200 Expansão da Sincronização do Jira (Usuários + Cargos)

### DIFF
--- a/apps/dashboards/management/commands/sync_jira_users.py
+++ b/apps/dashboards/management/commands/sync_jira_users.py
@@ -25,79 +25,112 @@ class Command(BaseCommand):
         de dados operacional, mantendo os existentes.
         """
         self.stdout.write("Iniciando a sincronização de utilizadores do Jira...")
+        projetos = self._buscar_dados_do_jira()
+        assignees, total_tasks = self._coletar_assignees(projetos)
 
-        jira_service = JiraService()
+        if not assignees:
+            self._informar_sem_assignees()
+            return
 
+        self._informar_quantidades(assignees, total_tasks)
+        resumo = self._processar_assignees(assignees)
+        self._exibir_resumo(resumo)
+
+    def _buscar_dados_do_jira(self):
         self.stdout.write("Buscando dados de projetos e tarefas do Jira...")
-        projetos_com_tasks = jira_service.get_all_tasks_data()
-
-        if projetos_com_tasks is None:
+        projetos = JiraService().get_all_tasks_data()
+        if projetos is None:
             raise CommandError(
                 "Falha ao buscar dados do Jira. Verifique a conexão e as credenciais."
             )
+        return projetos
 
+    def _coletar_assignees(self, projetos):
         assignees = set()
         total_tasks_processadas = 0
-        for projeto in projetos_com_tasks:
-            for task in projeto.get("tasks", []):
+        for projeto in projetos:
+            tasks = projeto.get("tasks", [])
+            for task in tasks:
                 assignee_name = task.get("assignee")
                 if assignee_name and assignee_name != "Sem responsável":
                     assignees.add(assignee_name.strip())
                 total_tasks_processadas += 1
+        return assignees, total_tasks_processadas
 
-        if not assignees:
-            self.stdout.write(
-                self.style.WARNING("Nenhum assignee encontrado nas tarefas do Jira.")
-            )
-            return
-
+    def _informar_sem_assignees(self):
         self.stdout.write(
-            f"Encontrados {len(assignees)} utilizadores únicos em {total_tasks_processadas} tarefas analisadas."
+            self.style.WARNING("Nenhum assignee encontrado nas tarefas do Jira.")
         )
 
-        criados = 0
-        atualizados = 0
-        usuarios_criados = 0
-        usuarios_existentes = 0
-        for nome_assignee in assignees:
-            funcionario, created = Funcionario.objects.update_or_create(
-                nome=nome_assignee,
-            )
-
-            if created:
-                criados += 1
-                self.stdout.write(
-                    f"  [CRIADO] Funcionário: {funcionario.nome} (ID: {funcionario.id}) com valor/hora padrão."
-                )
-            else:
-                atualizados += 1
-
-            try:
-                placeholder = garantir_usuario_placeholder(nome_assignee)
-            except ValueError:
-                self.stdout.write(
-                    self.style.WARNING(
-                        f"  [USUARIO] Nome inválido ao criar placeholder para '{nome_assignee}'."
-                    )
-                )
-                continue
-
-            if placeholder.criado:
-                usuarios_criados += 1
-                self.stdout.write(
-                    f"  [USUARIO] Criado placeholder '{placeholder.usuario.username}' para {nome_assignee}."
-                )
-            else:
-                usuarios_existentes += 1
-
-        self.stdout.write(self.style.SUCCESS("\nSincronização concluída com sucesso!"))
-        self.stdout.write(self.style.SUCCESS(f"  - {criados} funcionários criados."))
+    def _informar_quantidades(self, assignees, total_tasks):
         self.stdout.write(
-            self.style.SUCCESS(f"  - {atualizados} funcionários já existentes.")
+            f"Encontrados {len(assignees)} utilizadores únicos em {total_tasks} tarefas analisadas."
+        )
+
+    def _processar_assignees(self, assignees):
+        resumo = {
+            "criados": 0,
+            "atualizados": 0,
+            "usuarios_criados": 0,
+            "usuarios_existentes": 0,
+        }
+
+        for nome_assignee in assignees:
+            if self._registrar_funcionario(nome_assignee):
+                resumo["criados"] += 1
+            else:
+                resumo["atualizados"] += 1
+
+            placeholder_status = self._garantir_placeholder(nome_assignee)
+            if placeholder_status == "criado":
+                resumo["usuarios_criados"] += 1
+            elif placeholder_status == "existente":
+                resumo["usuarios_existentes"] += 1
+
+        return resumo
+
+    def _registrar_funcionario(self, nome_assignee):
+        funcionario, criado = Funcionario.objects.update_or_create(
+            nome=nome_assignee,
+        )
+
+        if criado:
+            self.stdout.write(
+                f"  [CRIADO] Funcionário: {funcionario.nome} (ID: {funcionario.id}) com valor/hora padrão."
+            )
+        return criado
+
+    def _garantir_placeholder(self, nome_assignee):
+        try:
+            placeholder = garantir_usuario_placeholder(nome_assignee)
+        except ValueError:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"  [USUARIO] Nome inválido ao criar placeholder para '{nome_assignee}'."
+                )
+            )
+            return "erro"
+
+        if placeholder.criado:
+            self.stdout.write(
+                f"  [USUARIO] Criado placeholder '{placeholder.usuario.username}' para {nome_assignee}."
+            )
+            return "criado"
+        return "existente"
+
+    def _exibir_resumo(self, resumo):
+        self.stdout.write(self.style.SUCCESS("\nSincronização concluída com sucesso!"))
+        self.stdout.write(
+            self.style.SUCCESS(f"  - {resumo['criados']} funcionários criados.")
         )
         self.stdout.write(
             self.style.SUCCESS(
-                f"  - {usuarios_criados} usuários placeholder criados "
-                f"({usuarios_existentes} já existiam)."
+                f"  - {resumo['atualizados']} funcionários já existentes."
+            )
+        )
+        self.stdout.write(
+            self.style.SUCCESS(
+                "  - {usuarios_criados} usuários placeholder criados "
+                "({usuarios_existentes} já existiam).".format(**resumo)
             )
         )

--- a/apps/dashboards/management/commands/sync_jira_users.py
+++ b/apps/dashboards/management/commands/sync_jira_users.py
@@ -2,6 +2,7 @@ from django.core.management.base import BaseCommand, CommandError
 
 from apps.dashboards.services import JiraService
 from apps.relatorios.models import Funcionario
+from apps.usuarios.utils import garantir_usuario_placeholder
 
 
 class Command(BaseCommand):
@@ -56,6 +57,8 @@ class Command(BaseCommand):
 
         criados = 0
         atualizados = 0
+        usuarios_criados = 0
+        usuarios_existentes = 0
         for nome_assignee in assignees:
             funcionario, created = Funcionario.objects.update_or_create(
                 nome=nome_assignee,
@@ -69,8 +72,32 @@ class Command(BaseCommand):
             else:
                 atualizados += 1
 
+            try:
+                placeholder = garantir_usuario_placeholder(nome_assignee)
+            except ValueError:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"  [USUARIO] Nome inválido ao criar placeholder para '{nome_assignee}'."
+                    )
+                )
+                continue
+
+            if placeholder.criado:
+                usuarios_criados += 1
+                self.stdout.write(
+                    f"  [USUARIO] Criado placeholder '{placeholder.usuario.username}' para {nome_assignee}."
+                )
+            else:
+                usuarios_existentes += 1
+
         self.stdout.write(self.style.SUCCESS("\nSincronização concluída com sucesso!"))
         self.stdout.write(self.style.SUCCESS(f"  - {criados} funcionários criados."))
         self.stdout.write(
             self.style.SUCCESS(f"  - {atualizados} funcionários já existentes.")
+        )
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"  - {usuarios_criados} usuários placeholder criados "
+                f"({usuarios_existentes} já existiam)."
+            )
         )

--- a/apps/usuarios/apps.py
+++ b/apps/usuarios/apps.py
@@ -4,3 +4,7 @@ from django.apps import AppConfig
 class UsuariosConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "apps.usuarios"
+
+    def ready(self):  # noqa: D401
+        """Registra sinais do app."""
+        from apps.usuarios import signals  # noqa: F401

--- a/apps/usuarios/signals.py
+++ b/apps/usuarios/signals.py
@@ -20,24 +20,26 @@ def _normalizar_sigla(cargo: str) -> str:
 def sincronizar_usuario_para_funcionarios(usuario: Usuario):
     """Atualiza o cargo dos funcionários com base no usuário correspondente."""
     nome = (usuario.nome_completo or "").strip()
-    Funcionario = django_apps.get_model(
+    funcionario_model = django_apps.get_model(
         "relatorios", "Funcionario"
     )  # pylint: disable=invalid-name
-    Cargo = django_apps.get_model("relatorios", "Cargo")  # pylint: disable=invalid-name
+    cargo_model = django_apps.get_model(
+        "relatorios", "Cargo"
+    )  # pylint: disable=invalid-name
 
     if not nome:
         return
 
-    funcionarios = Funcionario.objects.filter(nome__iexact=nome)
+    funcionarios = funcionario_model.objects.filter(nome__iexact=nome)
     if not funcionarios.exists():
         return
 
     sigla = _normalizar_sigla(usuario.cargo)
     cargo_obj = None
     if sigla:
-        cargo_obj = Cargo.objects.filter(sigla__iexact=sigla).first()
+        cargo_obj = cargo_model.objects.filter(sigla__iexact=sigla).first()
         if not cargo_obj:
-            cargo_obj = Cargo.objects.create(sigla=sigla)
+            cargo_obj = cargo_model.objects.create(sigla=sigla)
 
     novo_id = cargo_obj.id if cargo_obj else None
     ids_atualizados = funcionarios.exclude(cargo_id=novo_id)

--- a/apps/usuarios/signals.py
+++ b/apps/usuarios/signals.py
@@ -1,0 +1,52 @@
+"""Sinais relacionados ao modelo de usuário."""
+
+from __future__ import annotations
+
+from django.apps import apps as django_apps
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from django.utils.text import slugify
+
+from apps.usuarios.models import Usuario
+
+
+def _normalizar_sigla(cargo: str) -> str:
+    if not cargo:
+        return ""
+    slug = slugify(cargo, allow_unicode=False)
+    return slug.replace("-", "_").upper()[:20]
+
+
+def sincronizar_usuario_para_funcionarios(usuario: Usuario):
+    """Atualiza o cargo dos funcionários com base no usuário correspondente."""
+    nome = (usuario.nome_completo or "").strip()
+    Funcionario = django_apps.get_model(
+        "relatorios", "Funcionario"
+    )  # pylint: disable=invalid-name
+    Cargo = django_apps.get_model("relatorios", "Cargo")  # pylint: disable=invalid-name
+
+    if not nome:
+        return
+
+    funcionarios = Funcionario.objects.filter(nome__iexact=nome)
+    if not funcionarios.exists():
+        return
+
+    sigla = _normalizar_sigla(usuario.cargo)
+    cargo_obj = None
+    if sigla:
+        cargo_obj = Cargo.objects.filter(sigla__iexact=sigla).first()
+        if not cargo_obj:
+            cargo_obj = Cargo.objects.create(sigla=sigla)
+
+    novo_id = cargo_obj.id if cargo_obj else None
+    ids_atualizados = funcionarios.exclude(cargo_id=novo_id)
+    if cargo_obj:
+        ids_atualizados.update(cargo=cargo_obj)
+    else:
+        ids_atualizados.update(cargo=None)
+
+
+@receiver(post_save, sender=Usuario)
+def usuario_post_save(sender, instance: Usuario, **_kwargs):
+    sincronizar_usuario_para_funcionarios(instance)

--- a/apps/usuarios/utils.py
+++ b/apps/usuarios/utils.py
@@ -1,0 +1,97 @@
+"""Utilitários para criação e sincronização automática de usuários."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.utils.text import slugify
+
+from apps.usuarios.models import PerfilAcessoChoices
+
+Usuario = get_user_model()
+
+
+@dataclass(frozen=True)
+class UsuarioPlaceholderResult:
+    """Estrutura auxiliar para indicar criação automática de usuários."""
+
+    usuario: Usuario
+    criado: bool
+
+
+def _limpar_nome(nome: str) -> str:
+    return " ".join((nome or "").split())
+
+
+def _username_base(nome: str, max_length: int) -> str:
+    slug = slugify(nome or "", allow_unicode=False)
+    username = slug.replace("-", ".").strip(".")
+    if not username:
+        username = "dev"
+
+    if len(username) > max_length:
+        username = username[:max_length]
+    return username
+
+
+def gerar_username_unico(nome: str) -> str:
+    """Gera um username único baseado no nome completo."""
+    max_length = Usuario._meta.get_field("username").max_length
+    base = _username_base(nome, max_length=max(4, max_length - 4))
+    username = base
+    sufixo = 1
+
+    while Usuario.objects.filter(username=username).exists():
+        suffix_str = str(sufixo)
+        limit = max_length - len(suffix_str)
+        trimmed = base[:limit] if limit > 0 else base
+        username = f"{trimmed}{suffix_str}"
+        sufixo += 1
+
+    return username
+
+
+def gerar_email_unico(username: str) -> str:
+    """Gera um e-mail fake único reutilizando o domínio padrão."""
+    domain = (settings.DEFAULT_DEV_USER_EMAIL_DOMAIN or "devs.local").strip()
+    if not domain:
+        domain = "devs.local"
+
+    base_email = f"{username}@{domain}"
+    if not Usuario.objects.filter(email=base_email).exists():
+        return base_email
+
+    sufixo = 1
+    while True:
+        email = f"{username}{sufixo}@{domain}"
+        if not Usuario.objects.filter(email=email).exists():
+            return email
+        sufixo += 1
+
+
+def garantir_usuario_placeholder(nome_completo: str) -> UsuarioPlaceholderResult:
+    """Cria (ou retorna) um usuário placeholder com senha padrão."""
+    nome_normalizado = _limpar_nome(nome_completo)
+    if not nome_normalizado:
+        raise ValueError("Nome do desenvolvedor não pode ser vazio.")
+
+    existente = Usuario.objects.filter(nome_completo__iexact=nome_normalizado).first()
+    if existente:
+        return UsuarioPlaceholderResult(usuario=existente, criado=False)
+
+    username = gerar_username_unico(nome_normalizado)
+    email = gerar_email_unico(username)
+
+    usuario = Usuario(
+        nome_completo=nome_normalizado,
+        username=username,
+        email=email,
+        cargo=settings.DEFAULT_DEV_USER_CARGO,
+        perfil_acesso=PerfilAcessoChoices.MEMBRO,
+        ativo=False,
+    )
+    usuario.set_password(settings.DEFAULT_DEV_USER_PASSWORD)
+    usuario.save()
+    return UsuarioPlaceholderResult(usuario=usuario, criado=True)

--- a/config/settings.py
+++ b/config/settings.py
@@ -254,6 +254,11 @@ CACHE_JIRA = {
     "validade": datetime.timedelta(minutes=10),
 }
 
+# Defaults used when criando usuários placeholder para desenvolvedores importados
+DEFAULT_DEV_USER_PASSWORD = get_env("DEFAULT_DEV_USER_PASSWORD", "ChangeMe123!")
+DEFAULT_DEV_USER_EMAIL_DOMAIN = get_env("DEFAULT_DEV_USER_EMAIL_DOMAIN", "devs.local")
+DEFAULT_DEV_USER_CARGO = get_env("DEFAULT_DEV_USER_CARGO", "NAO_DEFINIDO")
+
 # Session management
 SESSION_COOKIE_AGE = env.int("SESSION_COOKIE_AGE", default=2 * 60 * 60)  # 2 hours
 SESSION_SAVE_EVERY_REQUEST = True  # refresh expiry on activity

--- a/tests/unit/apps/dashboards/management/commands/test_sync_jira_users.py
+++ b/tests/unit/apps/dashboards/management/commands/test_sync_jira_users.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 from io import StringIO
 from unittest.mock import patch
 
+from django.contrib.auth import get_user_model
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
@@ -10,6 +11,7 @@ from apps.dashboards.services import JiraService  # pylint: disable=unused-impor
 from apps.relatorios.models import Funcionario
 
 VALOR_HORA_PADRAO = Decimal("40.00")
+Usuario = get_user_model()
 
 
 class SyncJiraUsersCommandTest(TestCase):
@@ -25,6 +27,7 @@ class SyncJiraUsersCommandTest(TestCase):
         Limpa os funcionários antes de cada teste.
         """
         Funcionario.objects.all().delete()
+        Usuario.objects.all().delete()
 
     @patch("apps.dashboards.services.JiraService.get_all_tasks_data")
     def test_sync_creates_new_funcionarios(self, mock_get_all_tasks_data):
@@ -45,10 +48,15 @@ class SyncJiraUsersCommandTest(TestCase):
         call_command("sync_jira_users", stdout=out)
 
         self.assertEqual(Funcionario.objects.count(), 2)
+        self.assertEqual(Usuario.objects.count(), 2)
         alice = Funcionario.objects.get(nome="Alice Wonderland")
         bob = Funcionario.objects.get(nome="Bob The Builder")
         self.assertEqual(alice.valor_hora, VALOR_HORA_PADRAO)
         self.assertEqual(bob.valor_hora, VALOR_HORA_PADRAO)
+        alice_user = Usuario.objects.get(nome_completo="Alice Wonderland")
+        self.assertEqual(alice_user.username, "alice.wonderland")
+        self.assertEqual(alice_user.email, "alice.wonderland@devs.local")
+        self.assertFalse(alice_user.ativo)
 
         output = out.getvalue()
         self.assertIn("Encontrados 2 utilizadores únicos", output)
@@ -56,6 +64,7 @@ class SyncJiraUsersCommandTest(TestCase):
         self.assertIn("[CRIADO] Funcionário: Bob The Builder", output)
         self.assertIn("2 funcionários criados.", output)
         self.assertIn("0 funcionários já existentes.", output)
+        self.assertIn("2 usuários placeholder criados (0 já existiam).", output)
 
     @patch("apps.dashboards.services.JiraService.get_all_tasks_data")
     def test_sync_does_not_duplicate_existing(self, mock_get_all_tasks_data):
@@ -64,6 +73,13 @@ class SyncJiraUsersCommandTest(TestCase):
         novos são criados corretamente.
         """
         Funcionario.objects.create(nome="Charlie Chaplin", valor_hora=Decimal("55.00"))
+        Usuario.objects.create_user(
+            username="charlie.chaplin",
+            nome_completo="Charlie Chaplin",
+            email="chaplin@example.com",
+            password="secret123",
+            cargo="NAO_DEFINIDO",
+        )
         self.assertEqual(Funcionario.objects.count(), 1)
 
         mock_get_all_tasks_data.return_value = [
@@ -75,10 +91,13 @@ class SyncJiraUsersCommandTest(TestCase):
         call_command("sync_jira_users", stdout=out)
 
         self.assertEqual(Funcionario.objects.count(), 2)
+        self.assertEqual(Usuario.objects.count(), 2)
         charlie = Funcionario.objects.get(nome="Charlie Chaplin")
         diana = Funcionario.objects.get(nome="Diana Prince")
         self.assertEqual(charlie.valor_hora, Decimal("55.00"))  # Mantém valor original
         self.assertEqual(diana.valor_hora, VALOR_HORA_PADRAO)  # Aplica padrão ao novo
+        diana_user = Usuario.objects.get(nome_completo="Diana Prince")
+        self.assertEqual(diana_user.username, "diana.prince")
 
         output = out.getvalue()
         self.assertIn("Encontrados 2 utilizadores únicos", output)
@@ -86,6 +105,7 @@ class SyncJiraUsersCommandTest(TestCase):
         self.assertNotIn("[CRIADO] Funcionário: Charlie Chaplin", output)
         self.assertIn("1 funcionários criados.", output)
         self.assertIn("1 funcionários já existentes.", output)
+        self.assertIn("1 usuários placeholder criados (1 já existiam).", output)
 
     @patch("apps.dashboards.services.JiraService.get_all_tasks_data")
     def test_sync_handles_no_assignees_found(self, mock_get_all_tasks_data):
@@ -103,6 +123,7 @@ class SyncJiraUsersCommandTest(TestCase):
         self.assertEqual(Funcionario.objects.count(), 0)
         output = out.getvalue()
         self.assertIn("Nenhum assignee encontrado nas tarefas do Jira.", output)
+        self.assertNotIn("usuários placeholder", output)
         self.assertNotIn("[CRIADO]", output)
 
     @patch("apps.dashboards.services.JiraService.get_all_tasks_data")

--- a/tests/unit/apps/usuarios/test_signals.py
+++ b/tests/unit/apps/usuarios/test_signals.py
@@ -1,0 +1,47 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from apps.relatorios.models import Cargo, Funcionario
+
+Usuario = get_user_model()
+
+
+class UsuarioSignalTests(TestCase):
+    def setUp(self):
+        Funcionario.objects.all().delete()
+        Cargo.objects.all().delete()
+
+    def test_salvar_usuario_atualiza_cargo_do_funcionario(self):
+        Funcionario.objects.create(nome="Ana Dev")
+
+        Usuario.objects.create_user(
+            username="ana.dev",
+            nome_completo="Ana Dev",
+            email="ana@example.com",
+            password="Secret123!",
+            cargo="Dev Backend",
+        )
+
+        funcionario = Funcionario.objects.get(nome="Ana Dev")
+        cargo = Cargo.objects.get(sigla="DEV_BACKEND")
+        self.assertEqual(funcionario.cargo, cargo)
+
+    def test_cargo_em_branco_remove_relacionamento(self):
+        cargo = Cargo.objects.create(sigla="QA")
+        Funcionario.objects.create(nome="Beto QA", cargo=cargo)
+
+        usuario = Usuario.objects.create_user(
+            username="beto.qa",
+            nome_completo="Beto QA",
+            email="beto@example.com",
+            password="Secret123!",
+            cargo="QA",
+        )
+        funcionario = Funcionario.objects.get(nome="Beto QA")
+        self.assertEqual(funcionario.cargo, cargo)
+
+        usuario.cargo = ""
+        usuario.save()
+
+        funcionario.refresh_from_db()
+        self.assertIsNone(funcionario.cargo)


### PR DESCRIPTION
Esta PR aprimora o comando de sincronização do Jira, incluindo agora o tratamento completo de **usuários (assignees)**, criação de **placeholders**, normalização de emails/usernames e **sincronização automática de cargos**, garantindo alinhamento entre os dados importados do Jira e os perfis existentes no Athos Insight.

## **1. Expansão do comando `sync_jira_users`**
Arquivo: `apps/dashboards/management/commands/sync_jira_users.py`

* O comando agora detecta todos os *assignees* retornados pela API do Jira.
* Cria **usuários placeholders** para perfis ainda não existentes no sistema.
* Ignora nomes inválidos ou ausentes, evitando criação incorreta de usuários.
* Exibe, ao final, um **resumo completo** com:

  * Quantos placeholders foram criados
  * Quantos já existiam
  * Quantos foram ignorados

## **2. Helpers para normalização de usuários**

Arquivos:

* `apps/usuarios/utils.py`
* `config/settings.py` (defaults entre lines 244–265)

Melhorias entregues:

* Geração padronizada de usernames e emails.
* Uso de sufixos incrementais para evitar colisões.
* Exposição da função `garantir_usuario_placeholder`, usada pelo comando.
* Novos *defaults* configuráveis via settings:

  * `DEFAULT_DEV_USER_PASSWORD`
  * `DEFAULT_DEV_USER_EMAIL_DOMAIN`
  * `DEFAULT_DEV_USER_CARGO`


## **3. Sincronização automática de cargos via sinais**

Arquivos:
* `apps/usuarios/apps.py` (registro do sinal no `ready()`)
* `apps/usuarios/signals.py`

Funcionalidade implementada:

* Cada vez que um `User` é salvo, o sinal `post_save` sincroniza automaticamente:

  * o **cargo** do funcionário correspondente (match pelo nome),
  * criando a **sigla do cargo** caso ainda não exista.
* Garante alinhamento entre funcionários (OLTP) e perfis do app.


## **4. Testes unitários atualizados e abrangentes**

Arquivos:

* `tests/unit/apps/dashboards/management/commands/test_sync_jira_users.py`
* `tests/unit/apps/usuarios/test_signals.py`

#  **Como Testar**

### **1. Configure os defaults**

Certifique-se de definir (ou usar os valores padrão em `settings`):

* `DEFAULT_DEV_USER_PASSWORD`
* `DEFAULT_DEV_USER_EMAIL_DOMAIN`
* `DEFAULT_DEV_USER_CARGO`

---

### **2. Rode os testes unitários**

Ative o virtualenv e execute:

```bash
python manage.py test \
    tests/unit/apps/dashboards/management/commands/test_sync_jira_users.py \
    tests/unit/apps/usuarios/test_signals.py
```

> Caso receba **python: command not found**, ative o ambiente correto ou use o binário do venv.

---

### **3. Teste manual com Jira**

Execute:

```bash
python manage.py sync_jira_users
```

Resultados esperados:

* Placeholders criados conforme assignees do Jira
* Nominalização correta de usernames/emails
* Funcionários sincronizados com cargos
* Resumo final exibido no console
